### PR TITLE
Added OLED output for layers 2 and 3 in vial keymap

### DIFF
--- a/keyboards/ffkeebs/puca/keymaps/vial/keymap.c
+++ b/keyboards/ffkeebs/puca/keymaps/vial/keymap.c
@@ -180,6 +180,12 @@ void oled_task_user(void) {
         case 1:
             oled_write_P(PSTR("FUNC\n"), false);
             break;
+        case 2:
+            oled_write_P(PSTR("MAC1\n"), false);
+            break;
+        case 3:
+            oled_write_P(PSTR("MAC2\n"), false);
+            break;
     }
 }
 #endif


### PR DESCRIPTION
I added OLED outputs for layers 2 and 3 which say MAC1 & MAC2 respectively.